### PR TITLE
Multi-line NSError.br_diagnosticDescription

### DIFF
--- a/Bedrock.xcodeproj/project.pbxproj
+++ b/Bedrock.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 				016B0E3121C773600034D4B9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		015C5A471C701EC400916261 /* Products */ = {
 			isa = PBXGroup;

--- a/Bedrock/NSError+Bedrock.m
+++ b/Bedrock/NSError+Bedrock.m
@@ -43,19 +43,40 @@
 	return self.userInfo[NSUnderlyingErrorKey];
 }
 
+static NSUInteger const br_NSErrorDiagnosticDescriptionIndentation = 4;
+
 - (NSString *)br_diagnosticDescription
 {
+	return [self br_diagnosticDescriptionWithIndentation:0];
+}
+
+- (NSString *)br_diagnosticDescriptionWithIndentation:(NSUInteger)indentation
+{
+	NSString *indentationString = [@"" stringByPaddingToLength:indentation withString:@" " startingAtIndex:0];
+	NSString *childIndentationString = [@"" stringByPaddingToLength:indentation + br_NSErrorDiagnosticDescriptionIndentation withString:@" " startingAtIndex:0];
 	NSMutableArray<NSString *> *userInfoStrings = [NSMutableArray new];
+	NSString *underlyingErrorInfoString = nil;
 	for (NSString *aKey in self.userInfo) {
-		if ([aKey isEqual:NSLocalizedDescriptionKey]) continue;	// this value will be included outside of the userinfo keys
+		if ([aKey isEqual:NSLocalizedDescriptionKey]) continue;    // this value will be included outside of the userinfo keys
 		id value = self.userInfo[aKey];
 		if ([aKey isEqual:NSUnderlyingErrorKey]) {
-			value = [NSString stringWithFormat:@"(%@)", [value br_diagnosticDescription]];
+			value = [NSString stringWithFormat:@"%@", [value br_diagnosticDescriptionWithIndentation:indentation + br_NSErrorDiagnosticDescriptionIndentation]];
+			underlyingErrorInfoString = [NSString stringWithFormat:@"underlyingError: %@", value];
+		} else {
+			[userInfoStrings addObject:[NSString stringWithFormat:@"%@: %@", aKey, value]];
 		}
-		[userInfoStrings addObject:[NSString stringWithFormat:@"%@: %@", aKey, value]];
 	}
-	NSString *userInfoText = userInfoStrings.count > 0 ? [NSString stringWithFormat:@" {%@}", [userInfoStrings componentsJoinedByString:@", "]] : @"";
-	return [NSString stringWithFormat:@"Error %@[%lld] '%@'%@", self.domain, (long long)self.code, self.localizedDescription, userInfoText];
+	if (underlyingErrorInfoString) [userInfoStrings addObject:underlyingErrorInfoString];
+	
+	NSString *userInfoText = @"";
+	if (userInfoStrings.count > 0) {
+		NSMutableArray<NSString *> *lines = [NSMutableArray new];
+		for (NSString *aString in userInfoStrings) {
+			[lines addObject:[NSString stringWithFormat:@"%@%@", childIndentationString, aString]];
+		}
+		userInfoText = [NSString stringWithFormat:@" {\n%@\n%@}", [lines componentsJoinedByString:@"\n"], indentationString];
+	}
+	return [NSString stringWithFormat:@"%@:%lld '%@'%@", self.domain, (long long)self.code, self.localizedDescription, userInfoText];
 }
 
 @end

--- a/BedrockTests/NSError+BedrockTests.m
+++ b/BedrockTests/NSError+BedrockTests.m
@@ -56,10 +56,13 @@
 - (void)test_diagnosticDescription
 {
 	NSError *error = [NSError br_errorWithDomain:@"Domain" code:123 description:@"An error occurred"];
-	expect(error.br_diagnosticDescription).to.equal(@"Error Domain[123] 'An error occurred'");
+	expect(error.br_diagnosticDescription).to.equal(@"Domain:123 'An error occurred'");
 	
-	NSError *error2 = [NSError br_errorWithDomain:@"AnotherDomain" code:456 underlyingError:error description:@"Something lower-level went wrong"];
-	expect(error2.br_diagnosticDescription).to.equal(@"Error AnotherDomain[456] 'Something lower-level went wrong' {NSUnderlyingError: (Error Domain[123] 'An error occurred')}");
+	NSError *error2 = [NSError errorWithDomain:@"Domain" code:456 userInfo:@{NSLocalizedDescriptionKey: @"An error occurred", @"myKey": @"myValue"}];
+	expect(error2.br_diagnosticDescription).to.equal(@"Domain:456 'An error occurred' {\n    myKey: myValue\n}");
+	
+	NSError *error3 = [NSError br_errorWithDomain:@"AnotherDomain" code:789 underlyingError:error description:@"Something lower-level went wrong"];
+	expect(error3.br_diagnosticDescription).to.equal(@"AnotherDomain:789 'Something lower-level went wrong' {\n    underlyingError: Domain:123 'An error occurred'\n}");
 }
 
 @end


### PR DESCRIPTION
`NSError.br_diagnosticDescription` now prints userInfo information over multiple lines with indentation, making nested errors easier to read.