### PR TITLE
Resolve localisation-related Xcode warnings

### DIFF
--- a/Bedrock.xcodeproj/project.pbxproj
+++ b/Bedrock.xcodeproj/project.pbxproj
@@ -456,10 +456,11 @@
 			};
 			buildConfigurationList = 015C5A401C701EC400916261 /* Build configuration list for PBXProject "Bedrock" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 015C5A3C1C701EC400916261;
 			productRefGroup = 015C5A471C701EC400916261 /* Products */;


### PR DESCRIPTION
This PR resolves project configuration warnings in newer versions of Xcode by using the standard identifier `en` instead of deprecated `English` as the development language, and enabling Base internationalisation. There no actual localised files in the project, so no other changes were necessary.