### PR TITLE
Correct deployment targets

### DIFF
--- a/Bedrock.xcodeproj/project.pbxproj
+++ b/Bedrock.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -617,7 +617,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -804,7 +804,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0104A06D21C9C3E900139402 /* Bedrock-macOS.xcconfig */;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -813,7 +813,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0104A06D21C9C3E900139402 /* Bedrock-macOS.xcconfig */;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
It looks like as part of the project restructuring (https://github.com/nsforge/Bedrock/pull/5), effective deployment targets of both iOS and macOS versions of the framework have changed from 9.0 and 10.11 to 12.1 and 10.12 respectively. I believe this was not intentional, and probably was caused by removal of deployment target settings from the config files (see `Config/Bedrock.xcconfig` change in [this commit](https://github.com/nsforge/Bedrock/commit/ae1f63bddc034d6f527712b105cfd7eedd731bc9#diff-cf08849aba4d12b2cbf277dd2c474883)) and usage of default target settings in the project file. This PR reverts this change by selecting previously effective deployment targets, allowing the framework to be backported. No code changes were required.